### PR TITLE
ENH: observable: actually check convergence

### DIFF
--- a/examples/cy_ising.pyx
+++ b/examples/cy_ising.pyx
@@ -121,7 +121,7 @@ def simulate(Py_ssize_t L,
         if sweep % num_prnt == 0:
             print("\n----- sweep = ", sweep, "spins = ", np.asarray(spins), "beta = ", beta)
             print("  ene = ", av_en / Z, " (naive)")
-            print("      = ", ene.mean, '+/-', ene.errorbar)
+            print("      = ", ene.mean, '+/-', ene.errorbar, ene.is_converged)
             th = tanh(beta)
             print("      = ", -L * th * (1 + th**(L-2)) / (1 + th**L), " (exact)" )
             # uncomment to check the block stats

--- a/mc_lib/_observable/chk_observable.cc
+++ b/mc_lib/_observable/chk_observable.cc
@@ -14,8 +14,11 @@ mc_stats::ScalarObservable<double> obs;
 obs << 1.0 ;
 obs << 2.0 ;
 obs << 3.0;
+for (size_t j=0; j < 10000 ; ++j) {
+   obs << 1.0*j;
+}
 
-std::cout << obs.mean() << "\n";
+std::cout << obs.mean() << std::boolalpha << "  " << obs.converged()<<"\n";
 
 }
 


### PR DESCRIPTION
Check if the errobar stabilizes with increasing block size. Only look at three elements at the end of the block stats errorbars
skipping the last element (if blocks are too large, there are only few blocks, errorbars can be unreliable).

Use an ad hoc cutoff: require that errorbars vary by no more than 15%.
