### PR TITLE
MACOS Frustrated Ising test

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -38,4 +38,7 @@ jobs:
         cd examples
         python setup.py build_ext --inplace
         python -c'from cy_ising import simulate; simulate(4, 1.25, 20000)'
-
+        
+         # also check that the 2D triangular Ising example runs
+        pip install jupyter
+        ipython -c"%run frustrated_2d_ising.ipynb"


### PR DESCRIPTION
I get some errors with `ipython run` for `frustrated_2D_Ising` with my meson build, so i've checked, if using setup.py will cause the same errors.
  [master-logs](https://github.com/ev-br/mc_lib/pull/25/checks?check_run_id=3127481012)
 [meson-master-logs](https://github.com/noDGodyaev/mc_lib/pull/3/checks?check_run_id=3127422853)