### PR TITLE
Add `.copy()` method to real observable

### DIFF
--- a/mc_lib/_observable/chk_observable.cc
+++ b/mc_lib/_observable/chk_observable.cc
@@ -20,5 +20,14 @@ for (size_t j=0; j < 10000 ; ++j) {
 
 std::cout << obs.mean() << std::boolalpha << "  " << obs.converged()<<"\n";
 
+
+mc_stats::ScalarObservable<double> obs1, obs2;
+obs1 << 1.0;
+
+obs2 = obs1;
+obs1 << 3.0;
+
+std::cout << obs1.mean() << " " << obs2.mean() << std::endl;
+
 }
 

--- a/mc_lib/_observable/observable.h
+++ b/mc_lib/_observable/observable.h
@@ -43,7 +43,7 @@ public:
     void from_blocks(const std::vector<T>& blocks, size_t Z_b);
 
     void operator<<(T x);    // add a measurement
-    ScalarObservable<T> operator=(ScalarObservable<T> val); 
+    ScalarObservable<T> operator=(const ScalarObservable<T>& val); 
     T mean() const;
     T errorbar() const;
     bool converged() const;
@@ -94,7 +94,7 @@ ScalarObservable<T>::operator<<(T x) {
 }
 
 template<typename T>
-ScalarObservable<T> ScalarObservable<T>::operator=(ScalarObservable<T> val){
+ScalarObservable<T> ScalarObservable<T>::operator=(const ScalarObservable<T>& val){
     _blocks = val._blocks;
     _value = val._value;
     _i_b = val._i_b;

--- a/mc_lib/_observable/observable.h
+++ b/mc_lib/_observable/observable.h
@@ -43,6 +43,7 @@ public:
     void from_blocks(const std::vector<T>& blocks, size_t Z_b);
 
     void operator<<(T x);    // add a measurement
+    ScalarObservable<T> operator=(ScalarObservable<T> val); 
     T mean() const;
     T errorbar() const;
     bool converged() const;
@@ -92,6 +93,15 @@ ScalarObservable<T>::operator<<(T x) {
     }
 }
 
+template<typename T>
+ScalarObservable<T> ScalarObservable<T>::operator=(ScalarObservable<T> val){
+    _blocks = val._blocks;
+    _value = val._value;
+    _i_b = val._i_b;
+    _Z_b = val._Z_b;
+    _n_b_max = val._n_b_max;
+    return *this;
+}
 
 // XXX: avoid recalculations, store mutable tuple(av, err, conv) instead? 
 template<typename T>

--- a/mc_lib/_observable/observable.h
+++ b/mc_lib/_observable/observable.h
@@ -43,7 +43,7 @@ public:
     void from_blocks(const std::vector<T>& blocks, size_t Z_b);
 
     void operator<<(T x);    // add a measurement
-    ScalarObservable<T> operator=(const ScalarObservable<T>& val); 
+    ScalarObservable& operator=(const ScalarObservable& val);
     T mean() const;
     T errorbar() const;
     bool converged() const;
@@ -93,8 +93,9 @@ ScalarObservable<T>::operator<<(T x) {
     }
 }
 
+
 template<typename T>
-ScalarObservable<T> ScalarObservable<T>::operator=(const ScalarObservable<T>& val){
+ScalarObservable<T>& ScalarObservable<T>::operator=(const ScalarObservable<T>& val){
     _blocks = val._blocks;
     _value = val._value;
     _i_b = val._i_b;
@@ -102,6 +103,7 @@ ScalarObservable<T> ScalarObservable<T>::operator=(const ScalarObservable<T>& va
     _n_b_max = val._n_b_max;
     return *this;
 }
+
 
 // XXX: avoid recalculations, store mutable tuple(av, err, conv) instead? 
 template<typename T>

--- a/mc_lib/observable.pxd
+++ b/mc_lib/observable.pxd
@@ -9,6 +9,7 @@ cdef extern from "_observable/observable.h" namespace "mc_stats":
         ScalarObservable(size_t b_n_max)   # FIXME: how to use from py/cy?
         void from_blocks(vector[T] blocks, size_t Z_b)
 
+        ScalarObservable[T] operator=(const ScalarObservable[T]& val)
         void operator<<(T value)
         T mean() const
         T errorbar() const

--- a/mc_lib/observable.pyx
+++ b/mc_lib/observable.pyx
@@ -33,6 +33,11 @@ cdef class RealObservable():
     def Z_b(self):
         return self._obs.Z_b()
 
+    def copy(self):
+        cdef RealObservable r = RealObservable()
+        r._obs = self._obs
+        return r
+
     cpdef void add_measurement(self, double value):
         self._obs << value
 

--- a/mc_lib/tests/test_observable.py
+++ b/mc_lib/tests/test_observable.py
@@ -66,3 +66,14 @@ def test_pickling():
         unpickled.add_measurement(j+20)
     assert_allclose(r.mean, unpickled.mean, atol=1e-14)
 
+
+def test_copying():
+    r1 = RealObservable()
+    r1.add_measurement(1.0)
+
+    r2 = r1.copy()
+    r2.add_measurement(3.0)
+
+    assert_allclose(r1.mean, 1, atol=1e-15)
+    assert_allclose(r2.mean, 2, atol=1e-15)
+


### PR DESCRIPTION
Finish up gh-60, so that `RealObservable` grows  the `.copy()` method.

closes gh-23
supersedes and closes gh-60